### PR TITLE
Overview exporters: remove Ganglia, add Graphite

### DIFF
--- a/content/docs/introduction/overview.md
+++ b/content/docs/introduction/overview.md
@@ -42,7 +42,7 @@ optional:
 * [client libraries](/docs/instrumenting/clientlibs/) for instrumenting application code
 * a [push gateway](https://github.com/prometheus/pushgateway) for supporting short-lived jobs
 * a [GUI-based dashboard builder](/docs/visualization/promdash/) based on Rails/SQL
-* special-purpose [exporters](/docs/instrumenting/exporters/) (for HAProxy, StatsD, Ganglia, etc.)
+* special-purpose [exporters](/docs/instrumenting/exporters/) (for HAProxy, StatsD, Graphite, etc.)
 * an (experimental) [alertmanager](https://github.com/prometheus/alertmanager)
 * a [command-line querying tool](https://github.com/prometheus/prometheus_cli)
 * various support tools


### PR DESCRIPTION
There is no Ganglia exporter listed in the [exporters doc](instrumenting/exporters.md) and support for gmond has been deprecated from the Node exporter, so I think we should remove Ganglia from the list here. I replaced with Graphite, but open to leaving it blank or picking some other example.

(cc @juliusv)